### PR TITLE
Updates method of getting form id in export

### DIFF
--- a/gravityforms-automatic-csv-export.php
+++ b/gravityforms-automatic-csv-export.php
@@ -133,7 +133,7 @@ class GravityFormsAutomaticCSVExport {
 	public function gforms_automated_export() {
 
 		$output = "";
-		$form_id = substr( current_filter() , -1);
+		$form_id = explode('_', current_filter())[2];
 		$form = GFAPI::get_form( $form_id ); // get form by ID 
 		$search_criteria = array();
 


### PR DESCRIPTION
Instead of using substr() to get the last character, split by "_" and get the last string.

Fixes the issue: [https://github.com/alexcavender/Automatic-Export-to-CSV-for-Gravity-Forms/issues/8](https://github.com/alexcavender/Automatic-Export-to-CSV-for-Gravity-Forms/issues/8)