### PR TITLE
Update the export function to handle names and addresses.

### DIFF
--- a/gravityforms-automatic-csv-export.php
+++ b/gravityforms-automatic-csv-export.php
@@ -175,6 +175,8 @@ class GravityFormsAutomaticCSVExport {
 
 		$all_form_entries = GFAPI::get_entries( $form_id , $search_criteria, null, $paging, $total_count);
 		
+		 // Create an array of field ids
+		$field_ids = array();
 
 		foreach( $form['fields'] as $field ) {
 
@@ -231,6 +233,9 @@ class GravityFormsAutomaticCSVExport {
 			}
 			continue;
 		}
+		
+		// Add field ids to array
+		array_push($field_ids, $field->id);
 
             $output .= preg_replace('/[,]/', '', $field->label) . ','; 
         }
@@ -242,25 +247,12 @@ class GravityFormsAutomaticCSVExport {
 	        foreach ( $all_form_entries as $entry ) {
 
 	            foreach($entry as $key => $val) {
-	                //skip blank values
-	                if(strlen($val) > 0) {
-
-	                    //if next value is not a decimal key but previous one was, stop appending for that field
-	                    if(strpos( $key, '.' ) === false && substr($output, strlen($output)-1, 1) == ' ') {
-	                        $output .= ',';
-	                    }
-
-	                    //decimal keys (EX: for a Name field which has several inputs)
-	                    if (is_numeric( $key ) && strpos( $key, '.' )) {
-	                        $output .= preg_replace('/[,]/', '', sanitize_text_field($val));
-	                        $output .= ' ';
-	                    }
-	                    else if (is_int($key)) { //regular integer key for standard fields
-	                        $output .= preg_replace('/[,]/', '', sanitize_text_field($val));
-	                        $output .= ',';
-	                    }
-	                }
-	            }
+			foreach($field_ids as $field_id) {
+				$val = rgar($entry, $field_id);
+				$output .= preg_replace('/[,]/', '', sanitize_text_field($val));
+				$output .= ',';
+			}
+		   }
 
 	            $output .= ',';
 	            $output .= "\r\n";

--- a/gravityforms-automatic-csv-export.php
+++ b/gravityforms-automatic-csv-export.php
@@ -178,8 +178,9 @@ class GravityFormsAutomaticCSVExport {
 
 		foreach( $form['fields'] as $field ) {
 
-            if($field->type == 'section') 
-                continue;
+		// Documentation is missing 'page' as a field type, not sure if there are any others that aren't in the documentation.  https://www.gravityhelp.com/documentation/article/field-object/
+		if(in_array($field->type, array('section','html','page'))
+			continue;
 
             //don't include hidden name fields
             if( $field->type == 'name' ) {

--- a/gravityforms-automatic-csv-export.php
+++ b/gravityforms-automatic-csv-export.php
@@ -182,7 +182,7 @@ class GravityFormsAutomaticCSVExport {
 		if(in_array($field->type, array('section','html','page'))
 			continue;
 
-            // handle name fields
+        	// handle name fields
 		if( $field->type == 'name' ) {
 			// TODO: Use field options to remove some fields from export
 			// Adds values for name extended 
@@ -202,6 +202,31 @@ class GravityFormsAutomaticCSVExport {
 				$str = lcfirst($str);
 				$str =  substr( $str, 0, 28 );
 			
+				$output .= preg_replace('/[,]/', '', $str) . ','; 
+			}
+			continue;
+		}
+		
+		// handle address fields
+		if( $field->type == 'address' ) {
+			// Adds values for name extended 
+			array_push($field_ids, $field['id'] . '.1');
+			array_push($field_ids, $field['id'] . '.2');
+			array_push($field_ids, $field['id'] . '.3');
+			array_push($field_ids, $field['id'] . '.4');
+			array_push($field_ids, $field['id'] . '.5');
+			array_push($field_ids, $field['id'] . '.6');
+			
+			foreach($field->inputs as $input) {
+				$noStrip = array();
+				$str = $field->label . " " . $input['label'];
+				$str = preg_replace('/[^a-z0-9' . implode("", $noStrip) . ']+/i', ' ', $str);
+				$str = trim($str);
+				$str = ucwords($str);
+				$str = str_replace(" ", "", $str);
+				$str = lcfirst($str);
+				$str =  substr( $str, 0, 28 );
+				
 				$output .= preg_replace('/[,]/', '', $str) . ','; 
 			}
 			continue;

--- a/gravityforms-automatic-csv-export.php
+++ b/gravityforms-automatic-csv-export.php
@@ -197,13 +197,6 @@ class GravityFormsAutomaticCSVExport {
 			foreach($field->inputs as $input) {
 				$noStrip = array();
 				$str = $field->label . " " . $input['label'];
-				$str = preg_replace('/[^a-z0-9' . implode("", $noStrip) . ']+/i', ' ', $str);
-				$str = trim($str);
-				$str = ucwords($str);
-				$str = str_replace(" ", "", $str);
-				$str = lcfirst($str);
-				$str =  substr( $str, 0, 28 );
-			
 				$output .= preg_replace('/[,]/', '', $str) . ','; 
 			}
 			continue;
@@ -222,13 +215,6 @@ class GravityFormsAutomaticCSVExport {
 			foreach($field->inputs as $input) {
 				$noStrip = array();
 				$str = $field->label . " " . $input['label'];
-				$str = preg_replace('/[^a-z0-9' . implode("", $noStrip) . ']+/i', ' ', $str);
-				$str = trim($str);
-				$str = ucwords($str);
-				$str = str_replace(" ", "", $str);
-				$str = lcfirst($str);
-				$str =  substr( $str, 0, 28 );
-				
 				$output .= preg_replace('/[,]/', '', $str) . ','; 
 			}
 			continue;

--- a/gravityforms-automatic-csv-export.php
+++ b/gravityforms-automatic-csv-export.php
@@ -133,7 +133,7 @@ class GravityFormsAutomaticCSVExport {
 	public function gforms_automated_export() {
 
 		$output = "";
-		$form_id = substr( current_filter() , -1);
+		$form_id = explode('_', current_filter())[2];
 		$form = GFAPI::get_form( $form_id ); // get form by ID 
 		$search_criteria = array();
 

--- a/gravityforms-automatic-csv-export.php
+++ b/gravityforms-automatic-csv-export.php
@@ -182,15 +182,30 @@ class GravityFormsAutomaticCSVExport {
 		if(in_array($field->type, array('section','html','page'))
 			continue;
 
-            //don't include hidden name fields
-            if( $field->type == 'name' ) {
-            	if ( !empty( $field->choices) ){
-	                foreach( $field->choices as $choice ) {
-	                    if( $choice->isHidden == 1 )
-	                        continue;
-	                }
-            	}
-            }
+            // handle name fields
+		if( $field->type == 'name' ) {
+			// TODO: Use field options to remove some fields from export
+			// Adds values for name extended 
+			array_push($field_ids, $field['id'] . '.2');
+			array_push($field_ids, $field['id'] . '.3');
+			array_push($field_ids, $field['id'] . '.4');
+			array_push($field_ids, $field['id'] . '.6');
+			array_push($field_ids, $field['id'] . '.8');
+
+			foreach($field->inputs as $input) {
+				$noStrip = array();
+				$str = $field->label . " " . $input['label'];
+				$str = preg_replace('/[^a-z0-9' . implode("", $noStrip) . ']+/i', ' ', $str);
+				$str = trim($str);
+				$str = ucwords($str);
+				$str = str_replace(" ", "", $str);
+				$str = lcfirst($str);
+				$str =  substr( $str, 0, 28 );
+			
+				$output .= preg_replace('/[,]/', '', $str) . ','; 
+			}
+			continue;
+		}
 
             $output .= preg_replace('/[,]/', '', $field->label) . ','; 
         }


### PR DESCRIPTION
Updates the export function to handle the names and addresses by creating an array of field ids and then looking these up for each entry. This allows more control over names and addresses, and also ignores values on the entries that aren't field values without all the str filters.

I accidentally left some code I use to camelCase the header fields, and then committed again to remove that.