### PR TITLE
PHP5.3 Compatibility Change

### DIFF
--- a/gravityforms-automatic-csv-export.php
+++ b/gravityforms-automatic-csv-export.php
@@ -133,7 +133,8 @@ class GravityFormsAutomaticCSVExport {
 	public function gforms_automated_export() {
 
 		$output = "";
-		$form_id = explode('_', current_filter())[2];
+		$current_filter = explode('_', current_filter());
+		$form_id = $current_filter[2];
 		$form = GFAPI::get_form( $form_id ); // get form by ID 
 		$search_criteria = array();
 


### PR DESCRIPTION
Small change that removes a direct array dereference from a returned function value, which is not possible in PHP version 5.3 and below.