### PR TITLE
Changed from selected columns to all columns.

### DIFF
--- a/automatic_csv_export_for_gravity_forms.php
+++ b/automatic_csv_export_for_gravity_forms.php
@@ -28,7 +28,7 @@ class GravityFormsAutomaticCSVExport {
 
 			global $wpdb;
 			$prefix = $wpdb->prefix;
-			$forms = $wpdb->get_results( "SELECT form_id, display_meta FROM " . $prefix . "rg_form_meta" );
+			$forms = $wpdb->get_results( "SELECT * FROM " . $prefix . "rg_form_meta" );
 
 			foreach ( $forms as $form ) {
 				$form_id = $form->form_id;


### PR DESCRIPTION
Hello alexcavender,

We have made a small change in automatic_csv_export_for_gravity_forms.php on line 31 added * instead of selecting particular columns. So plugin exports all data of form regardless of which fields are there in form. Please merge our branch in master.

Thanks.