### PR TITLE
Check form has an automatic CSV export object before trying to access its properties.

### DIFF
--- a/automatic_csv_export_for_gravity_forms.php
+++ b/automatic_csv_export_for_gravity_forms.php
@@ -207,6 +207,20 @@ class GravityFormsAutomaticCSVExport {
 	}
 
 
+	/**
+		* Get GMT date
+		*
+		* @param String	$local_date Local date
+		* @return String $date GMT date
+	*/
+	public static function get_gmt_date( $local_date ) {
+		$local_timestamp = strtotime( $local_date );
+		$gmt_timestamp   = GFCommon::get_gmt_timestamp( $local_timestamp );
+		$date            = gmdate( 'Y-m-d H:i:s', $gmt_timestamp );
+		return $date;
+	}
+
+
 	public static function start_automated_export( $form, $offset = 0, $export_id = '' ) {
 
 		$time_start         = microtime( true );

--- a/automatic_csv_export_for_gravity_forms.php
+++ b/automatic_csv_export_for_gravity_forms.php
@@ -36,7 +36,7 @@ class GravityFormsAutomaticCSVExport {
 				$decode = json_decode( $display_meta );
 
 				if ( $decode ){
-					$enabled = $decode->automatic_csv_export_for_gravity_forms->enabled;
+					$enabled = isset( $decode->automatic_csv_export_for_gravity_forms ) ? $decode->automatic_csv_export_for_gravity_forms->enabled : 0;
 					if ( $enabled == 1 ) {
 						add_action( 'csv_export_' . $form_id , array( $this, 'gforms_automated_export' ) );
 					}
@@ -100,7 +100,7 @@ class GravityFormsAutomaticCSVExport {
 
 			$form_id = $form['id'];
 
-			$enabled = $form['automatic_csv_export_for_gravity_forms']['enabled'];
+			$enabled = isset( $form['automatic_csv_export_for_gravity_forms'] ) ? $form['automatic_csv_export_for_gravity_forms']['enabled'] : 0;
 
 			if ( $enabled == 1 ) {
 


### PR DESCRIPTION
The plugin throws several PHP warnings following activation when `WP_DEBUG` is set to `true`, due to the code attempting to access properties on an object that doesn't yet exist.

This PR checks for the existence of the object before attempting to access its properties.